### PR TITLE
Add Zombie's working summon command for npcs's and weapons w/ charge.

### DIFF
--- a/dnModIce/Classes/IceConsole.uc
+++ b/dnModIce/Classes/IceConsole.uc
@@ -104,6 +104,16 @@ event bool KeyEvent(EInputKey Key, EInputAction Action, float Delta)
 }
 
 // ZOMBIE BEGIN
+exec function Summon(string ClassName)
+{
+    Root.GetPlayerOwner().Summon(ClassName);
+}
+
+exec function GiveItem(string ItemName, optional int Charge)
+{
+    DukePlayer(Root.GetPlayerOwner()).GiveItem(ItemName, Charge);
+}
+
 exec function God()
 {
     Root.GetPlayerOwner().God();


### PR DESCRIPTION
Allows you to summon/create a npc/enemy at cursor position with cmd, can also be used in user.ini as hotkeys for fast gameplay. The weapon summon one accepts a charge/ammo amount as well. *Note rebuild dnModIce.u*